### PR TITLE
adding K8S Nodeless Jenkins, Helm, Draft and Heapster Demos

### DIFF
--- a/devops/aks/nodelessKubernetesOnK8S/README.md
+++ b/devops/aks/nodelessKubernetesOnK8S/README.md
@@ -1,0 +1,90 @@
+Kubernetes Code Components Meetup
+=================================
+Presentation
+------------
+[Kubernetes Code Components](https://ptdrv.linkedin.com/dif0yfi)
+[Original Github Project](https://github.com/idanshahar/K8SCodeComponentsMeetup)
+
+Prerequisites
+------------
+1. A running Kubernetes Cluster - [AKS Instructions](https://docs.microsoft.com/en-us/azure/aks/tutorial-kubernetes-deploy-cluster)
+2. Helm - [Installation Instructions](https://github.com/kubernetes/helm/blob/master/docs/install.md)
+3. Draft - [Installation Instructions](https://github.com/Azure/draft/blob/master/docs/install.md)
+4. kubectl - [Installation Instructions](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+5. Docker - [Installation Instructions](https://docs.docker.com/install/)
+
+
+
+Nodeless Jenkins on Kubernetes
+------------------------------
+### Set up Jenkins using helm
+
+[![asciicast](https://asciinema.org/a/OZqZ4kN3GeqSsj63DxhgiSgvD.png)](https://asciinema.org/a/OZqZ4kN3GeqSsj63DxhgiSgvD?size=small)
+
+```
+# if this is the first time you are using helm, please uncomment the line below.
+
+# helm init
+
+helm install --name jenkins stable/jenkins
+
+# Alternatively, if you are having issues with the persistant volume class, you can still install jenkins from the chart provided in this repo:
+# helm install --name jenkins jenkins-helm/.
+# or to pass the storage class parameter:
+helm install --name jenkins stable/jenkins --set Persistence.StorageClass=default
+
+# the provided chart also Adds ACI plugin and Azure AD plugin (needs to be configured though)
+```
+### Get Jenkins admin password
+```
+printf $(kubectl get secret --namespace default jenkins-jenkins -o jsonpath="{.data.jenkins-admin-password}" | base64 --decode);echo
+```
+### Build a Docker Image for Jenkins Slave on your own
+```
+git clone https://github.com/idanshahar/K8SCodeComponentsMeetup.git
+
+cd KubernetesCodeComponents/jenkins
+
+docker build . --tag ${YOUR_DOCKER_REGISTRY}:${TAG}
+
+docker push ${YOUR_DOCKER_REGISTRY}:${TAG}
+```
+
+### Jenkins Configuration
+Go to "Manage Jenkins" -> "Configure System"
+
+1. Under Container Template, change the Docker Image to: idanshahar/jenkins-slave:latest
+2. Add the following host path volumes: /var/run/docker.sock, /usr/bin/docker 
+3. Create a new Pipeline job and select the jenkins file from git
+4. Change kubernetes url to 10.0.0.1
+
+Go to "Credentials" -> "System" -> "Global credentials" -> "Add Credentials"
+
+1. Choose "Global" Scope
+2. Add your Dockerhub credentials
+3. Insert 'docker-hub-credentials' as the credentialls ID 
+
+Containerize applications using Draft
+-------------------------------------
+```
+# cd to your app root folder
+cd node-draft
+
+draft init #initialize draft
+
+draft create 
+
+draft up
+```
+
+Monitoring
+----------
+[Official Kubernetes Metrics Project](https://github.com/kubernetes/metrics)
+
+#### Implementations
+1. [Heapster](https://github.com/kubernetes/heapster)
+2. [Metrics Server](https://github.com/kubernetes-incubator/metrics-server)
+3. [Prometheus Adapter](https://github.com/directxman12/k8s-prometheus-adapter)
+4. [Google Stackdriver](https://github.com/GoogleCloudPlatform/k8s-stackdriver) (coming soon)
+
+

--- a/devops/aks/nodelessKubernetesOnK8S/heapster/grafana.yaml
+++ b/devops/aks/nodelessKubernetesOnK8S/heapster/grafana.yaml
@@ -1,0 +1,72 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: monitoring-grafana
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        task: monitoring
+        k8s-app: grafana
+    spec:
+      containers:
+      - name: grafana
+        image: k8s.gcr.io/heapster-grafana-amd64:v4.4.3
+        ports:
+        - containerPort: 3000
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /etc/ssl/certs
+          name: ca-certificates
+          readOnly: true
+        - mountPath: /var
+          name: grafana-storage
+        env:
+        - name: INFLUXDB_HOST
+          value: monitoring-influxdb
+        - name: GF_SERVER_HTTP_PORT
+          value: "3000"
+          # The following env variables are required to make Grafana accessible via
+          # the kubernetes api-server proxy. On production clusters, we recommend
+          # removing these env variables, setup auth for grafana, and expose the grafana
+          # service using a LoadBalancer or a public IP.
+        - name: GF_AUTH_BASIC_ENABLED
+          value: "false"
+        - name: GF_AUTH_ANONYMOUS_ENABLED
+          value: "true"
+        - name: GF_AUTH_ANONYMOUS_ORG_ROLE
+          value: Admin
+        - name: GF_SERVER_ROOT_URL
+          # If you're only using the API Server proxy, set this value instead:
+          # value: /api/v1/namespaces/kube-system/services/monitoring-grafana/proxy
+          value: /
+      volumes:
+      - name: ca-certificates
+        hostPath:
+          path: /etc/ssl/certs
+      - name: grafana-storage
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    # For use as a Cluster add-on (https://github.com/kubernetes/kubernetes/tree/master/cluster/addons)
+    # If you are NOT using this as an addon, you should comment out this line.
+   # kubernetes.io/cluster-service: 'true'
+    kubernetes.io/name: monitoring-grafana
+  name: monitoring-grafana
+  namespace: kube-system
+spec:
+  # In a production setup, we recommend accessing Grafana through an external Loadbalancer
+  # or through a public IP.
+  type: LoadBalancer
+  # You could also use NodePort to expose the service at a randomly-generated port
+  # type: NodePort
+  ports:
+  - port: 80
+    targetPort: 3000
+  selector:
+    k8s-app: grafana

--- a/devops/aks/nodelessKubernetesOnK8S/heapster/heapster.yaml
+++ b/devops/aks/nodelessKubernetesOnK8S/heapster/heapster.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: heapster
+  namespace: kube-system
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: heapster
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        task: monitoring
+        k8s-app: heapster
+    spec:
+      serviceAccountName: heapster
+      containers:
+      - name: heapster
+        image: k8s.gcr.io/heapster-amd64:v1.4.2
+        imagePullPolicy: IfNotPresent
+        command:
+        - /heapster
+        - --source=kubernetes
+        - --sink=influxdb:http://monitoring-influxdb.kube-system.svc:8086
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    task: monitoring
+    # For use as a Cluster add-on (https://github.com/kubernetes/kubernetes/tree/master/cluster/addons)
+    # If you are NOT using this as an addon, you should comment out this line.
+   #kubernetes.io/cluster-service: 'true'
+    kubernetes.io/name: Heapster
+  name: heapster
+  namespace: kube-system
+spec:
+  ports:
+  - port: 80
+    targetPort: 8082
+  selector:
+    k8s-app: heapster

--- a/devops/aks/nodelessKubernetesOnK8S/heapster/influxdb.yaml
+++ b/devops/aks/nodelessKubernetesOnK8S/heapster/influxdb.yaml
@@ -1,0 +1,40 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: monitoring-influxdb
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        task: monitoring
+        k8s-app: influxdb
+    spec:
+      containers:
+      - name: influxdb
+        image: k8s.gcr.io/heapster-influxdb-amd64:v1.3.3
+        volumeMounts:
+        - mountPath: /data
+          name: influxdb-storage
+      volumes:
+      - name: influxdb-storage
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    task: monitoring
+    # For use as a Cluster add-on (https://github.com/kubernetes/kubernetes/tree/master/cluster/addons)
+    # If you are NOT using this as an addon, you should comment out this line.
+   # kubernetes.io/cluster-service: 'true'
+    kubernetes.io/name: monitoring-influxdb
+  name: monitoring-influxdb
+  namespace: kube-system
+spec:
+  ports:
+  - port: 8086
+    targetPort: 8086
+  selector:
+    k8s-app: influxdb

--- a/devops/aks/nodelessKubernetesOnK8S/helm-install-jenkins.json
+++ b/devops/aks/nodelessKubernetesOnK8S/helm-install-jenkins.json
@@ -1,0 +1,650 @@
+{
+  "version": 1,
+  "width": 208,
+  "height": 52,
+  "duration": 30.014206,
+  "command": null,
+  "title": null,
+  "env": {
+    "TERM": "xterm-256color",
+    "SHELL": "/bin/zsh"
+  },
+  "stdout": [
+    [
+      0.955097,
+      "\u001b]1337;RemoteHost=idanshahar@Idans-MacBook-Pro.local\u0007\u001b]1337;CurrentDir=/Users/idanshahar/sandbox/Meetups/KubernetesCodeComponents\u0007\u001b]1337;ShellIntegrationVersion=5;shell=zsh\u0007"
+    ],
+    [
+      0.003375,
+      "\u001b[1m\u001b[7m%\u001b[27m\u001b[1m\u001b[0m                                                                                                                                                                                                               \r \r"
+    ],
+    [
+      0.0001,
+      "\u001b]2;idanshahar@Idans-MacBook-Pro: ~/sandbox/Meetups/KubernetesCodeComponents\u0007"
+    ],
+    [
+      2e-05,
+      "\u001b]1;..odeComponents\u0007"
+    ],
+    [
+      7.7e-05,
+      "\u001b]133;D;0\u0007"
+    ],
+    [
+      3.9e-05,
+      "\u001b]1337;RemoteHost=idanshahar@Idans-MacBook-Pro.local\u0007\u001b]1337;CurrentDir=/Users/idanshahar/sandbox/Meetups/KubernetesCodeComponents\u0007"
+    ],
+    [
+      0.095946,
+      "\r\u001b[0m\u001b[27m\u001b[24m\u001b[J\u001b]133;A\u0007\u001b[39m\u001b[0m\u001b[49m\u001b[40m\u001b[39m idanshahar@Idans-MacBook-Pro \u001b[44m\u001b[30m\u001b[30m ~/sandbox/Meetups/KubernetesCodeComponents \u001b[43m\u001b[34m\u001b[30m  master ● \u001b[49m\u001b[33m\u001b[39m \u001b]133;B\u0007\u001b[K"
+    ],
+    [
+      0.000153,
+      "\u001b[?1h\u001b="
+    ],
+    [
+      2.1e-05,
+      "\u001b[?2004h"
+    ],
+    [
+      1.0,
+      "k"
+    ],
+    [
+      0.191136,
+      "\bku"
+    ],
+    [
+      0.12799,
+      "b"
+    ],
+    [
+      0.084329,
+      "e"
+    ],
+    [
+      0.205665,
+      "c"
+    ],
+    [
+      0.360007,
+      "t"
+    ],
+    [
+      0.169461,
+      "l"
+    ],
+    [
+      0.276482,
+      " "
+    ],
+    [
+      0.260784,
+      "g"
+    ],
+    [
+      0.088195,
+      "e"
+    ],
+    [
+      0.147932,
+      "t"
+    ],
+    [
+      0.119771,
+      " "
+    ],
+    [
+      0.215408,
+      "p"
+    ],
+    [
+      0.0758,
+      "o"
+    ],
+    [
+      0.052084,
+      "d"
+    ],
+    [
+      0.072271,
+      "s"
+    ],
+    [
+      0.184588,
+      "\u001b[?1l\u001b>"
+    ],
+    [
+      4e-05,
+      "\u001b[?2004l\r\r\n"
+    ],
+    [
+      0.000992,
+      "\u001b]2;kubectl get pods\u0007\u001b]1;kubectl\u0007"
+    ],
+    [
+      0.000105,
+      "\u001b]133;C;\u0007"
+    ],
+    [
+      0.730332,
+      "NAME                                       READY     STATUS    RESTARTS   AGE\r\nnode-example-javascript-1802202654-75r3r   1/1       Running   0          1h\r\nnode-example-javascript-1802202654-kb8rk   1/1       Running   0          1h\r\n"
+    ],
+    [
+      0.002054,
+      "\u001b[1m\u001b[7m%\u001b[27m\u001b[1m\u001b[0m                                                                                                                                                                                                               \r \r"
+    ],
+    [
+      0.000124,
+      "\u001b]2;idanshahar@Idans-MacBook-Pro: ~/sandbox/Meetups/KubernetesCodeComponents\u0007\u001b]1;..odeComponents\u0007"
+    ],
+    [
+      9.9e-05,
+      "\u001b]133;D;0\u0007\u001b]1337;RemoteHost=idanshahar@Idans-MacBook-Pro.local\u0007\u001b]1337;CurrentDir=/Users/idanshahar/sandbox/Meetups/KubernetesCodeComponents\u0007"
+    ],
+    [
+      0.09801,
+      "\r\u001b[0m\u001b[27m\u001b[24m\u001b[J\u001b]133;A\u0007\u001b[39m\u001b[0m\u001b[49m\u001b[40m\u001b[39m idanshahar@Idans-MacBook-Pro \u001b[44m\u001b[30m\u001b[30m ~/sandbox/Meetups/KubernetesCodeComponents \u001b[43m\u001b[34m\u001b[30m  master ● \u001b[49m\u001b[33m\u001b[39m \u001b]133;B\u0007\u001b[K"
+    ],
+    [
+      0.000112,
+      "\u001b[?1h\u001b=\u001b[?2004h"
+    ],
+    [
+      1.0,
+      "h"
+    ],
+    [
+      0.126105,
+      "\bhe"
+    ],
+    [
+      0.161837,
+      "l"
+    ],
+    [
+      0.210114,
+      "m"
+    ],
+    [
+      0.143915,
+      " "
+    ],
+    [
+      0.141931,
+      "i"
+    ],
+    [
+      0.177902,
+      "n"
+    ],
+    [
+      0.09235,
+      "s"
+    ],
+    [
+      0.191784,
+      "t"
+    ],
+    [
+      0.119889,
+      "a"
+    ],
+    [
+      0.116116,
+      "l"
+    ],
+    [
+      0.171321,
+      "l"
+    ],
+    [
+      0.57646,
+      " "
+    ],
+    [
+      0.742157,
+      "-"
+    ],
+    [
+      0.142069,
+      "-"
+    ],
+    [
+      0.249861,
+      "n"
+    ],
+    [
+      0.098021,
+      "a"
+    ],
+    [
+      0.15197,
+      "m"
+    ],
+    [
+      0.129988,
+      "e"
+    ],
+    [
+      0.264901,
+      " "
+    ],
+    [
+      0.24178,
+      "m"
+    ],
+    [
+      0.247348,
+      "y"
+    ],
+    [
+      0.443912,
+      "-"
+    ],
+    [
+      0.398848,
+      "j"
+    ],
+    [
+      0.108488,
+      "e"
+    ],
+    [
+      0.091631,
+      "n"
+    ],
+    [
+      0.190166,
+      "k"
+    ],
+    [
+      0.160906,
+      "i"
+    ],
+    [
+      0.181035,
+      "n"
+    ],
+    [
+      0.095973,
+      "s"
+    ],
+    [
+      0.10402,
+      " "
+    ],
+    [
+      0.63392,
+      "-"
+    ],
+    [
+      0.965901,
+      "\b \b"
+    ],
+    [
+      0.940971,
+      "s"
+    ],
+    [
+      0.204071,
+      "t"
+    ],
+    [
+      0.166988,
+      "a"
+    ],
+    [
+      0.188092,
+      "b"
+    ],
+    [
+      0.110915,
+      "l"
+    ],
+    [
+      0.123085,
+      "e"
+    ],
+    [
+      0.138887,
+      "/"
+    ],
+    [
+      0.620245,
+      "j"
+    ],
+    [
+      0.088753,
+      "e"
+    ],
+    [
+      0.112079,
+      "n"
+    ],
+    [
+      0.185895,
+      "k"
+    ],
+    [
+      0.147116,
+      "i"
+    ],
+    [
+      0.177828,
+      "n"
+    ],
+    [
+      0.102347,
+      "s"
+    ],
+    [
+      0.731389,
+      "\u001b[?1l\u001b>"
+    ],
+    [
+      3e-05,
+      "\u001b[?2004l\r\r\n"
+    ],
+    [
+      0.000973,
+      "\u001b]2;helm install --name my-jenkins stable/jenkins\u0007\u001b]1;helm\u0007"
+    ],
+    [
+      2.8e-05,
+      "\u001b]133;C;\u0007"
+    ],
+    [
+      1.0,
+      "NAME:   my-jenkins\r\n"
+    ],
+    [
+      0.499379,
+      "LAST DEPLOYED: Tue Feb 13 14:02:58 2018\r\nNAMESPACE: default\r\nSTATUS: DEPLOYED\r\n\r\n"
+    ],
+    [
+      7.5e-05,
+      "RESOURCES:\r\n==> v1/Secret\r\nNAME                TYPE    DATA  AGE\r\nmy-jenkins-jenkins  "
+    ],
+    [
+      0.000103,
+      "Opaque  2     1s\r\n\r\n==> v1/ConfigMap\r\nNAME                      DATA  AGE\r\nmy-jenkins-jenkins"
+    ],
+    [
+      6e-05,
+      "        3     1s\r\nmy-jenkins-jenkins-tests  1     1s\r\n\r\n==> v1/PersistentVolumeClaim\r\nNAME                STATUS   VOLUME"
+    ],
+    [
+      4.2e-05,
+      "   CAPACITY  ACCESS MODES  STORAGECLASS  AGE\r\nmy-jenkins-jenkins  Pending  default  1s\r\n\r\n"
+    ],
+    [
+      7.2e-05,
+      "==> v1/Service\r\nNAME        "
+    ],
+    [
+      5.4e-05,
+      "              TYPE          CLUSTER-IP    EXTERNAL-IP  PORT(S)         AGE\r\nmy-jenkins-jenkins-agent  ClusterIP     10.0.24.209   <none>       50000/TCP       1s\r\nmy-jenkins-jenkins        "
+    ],
+    [
+      2.9e-05,
+      "LoadBalancer  10.0.143.119  <pending>    8080:31744/TCP  1s\r\n\r\n==> v1beta1/Deployment\r\n"
+    ],
+    [
+      2.5e-05,
+      "NAME                DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  "
+    ],
+    [
+      3.2e-05,
+      "AGE\r\nmy-jenkins-jenkins  1        1        1        "
+    ],
+    [
+      3.2e-05,
+      "   0          1s\r\n\r\n==> v1/Pod(related)\r\nNAME"
+    ],
+    [
+      3.4e-05,
+      "                                 READY  STATUS   RESTARTS  AGE\r\n"
+    ],
+    [
+      2.6e-05,
+      "my-jenkins-jenkins-3228283227-4jtpd  0/1    Pending  0"
+    ],
+    [
+      3.1e-05,
+      "         1s\r\n\r\n\r\n"
+    ],
+    [
+      3.7e-05,
+      "NOTES:\r\n1. Get your 'admin' user password by running:\r\n  printf $(kubectl get secret --namespace default my-jenkins-jenkins -o jsonpath=\"{.data.jenkins-admin-password}\" | base64 --decode);echo\r\n2. Get the Jenkins URL to visit by running these commands in the same shell:\r\n  NOTE: It may take a few minutes for the LoadBalancer IP to be available.\r\n        You can watch the status of by running 'kubectl get svc --namespace default -w my-jenkins-jenkins'\r\n  export SERVICE_IP=$(kubectl get svc --namespace default my-jenkins-jenkins --template \"{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}\")\r\n  echo http://$SERVICE_IP:8080/login\r\n\r\n3. Login with the password from step 1 and the username: admin\r\n\r\nFor more information on running Jenkins on Kubernetes, visit:\r\nhttps://cloud.google.com/solutions/jenkins-on-container-engine\r\n\r\n"
+    ],
+    [
+      0.006545,
+      "\u001b[1m\u001b[7m%\u001b[27m\u001b[1m\u001b[0m                                                                                                                                                                                                               \r \r"
+    ],
+    [
+      0.000128,
+      "\u001b]2;idanshahar@Idans-MacBook-Pro: ~/sandbox/Meetups/KubernetesCodeComponents\u0007\u001b]1;..odeComponents\u0007"
+    ],
+    [
+      0.000168,
+      "\u001b]133;D;0\u0007\u001b]1337;RemoteHost=idanshahar@Idans-MacBook-Pro.local\u0007\u001b]1337;CurrentDir=/Users/idanshahar/sandbox/Meetups/KubernetesCodeComponents\u0007"
+    ],
+    [
+      0.105764,
+      "\r\u001b[0m\u001b[27m\u001b[24m\u001b[J\u001b]133;A\u0007\u001b[39m\u001b[0m\u001b[49m\u001b[40m\u001b[39m idanshahar@Idans-MacBook-Pro \u001b[44m\u001b[30m\u001b[30m ~/sandbox/Meetups/KubernetesCodeComponents \u001b[43m\u001b[34m\u001b[30m  master ● \u001b[49m\u001b[33m\u001b[39m \u001b]133;B\u0007\u001b[K"
+    ],
+    [
+      2.5e-05,
+      "\u001b[?1h\u001b="
+    ],
+    [
+      5.3e-05,
+      "\u001b[?2004h"
+    ],
+    [
+      1.0,
+      "k"
+    ],
+    [
+      0.180385,
+      "\bku"
+    ],
+    [
+      0.067965,
+      "b"
+    ],
+    [
+      0.136005,
+      "e"
+    ],
+    [
+      0.274721,
+      "c"
+    ],
+    [
+      0.097223,
+      "tl\u001b[1m \u001b[0m"
+    ],
+    [
+      0.661026,
+      "\b\u001b[0m g"
+    ],
+    [
+      0.071916,
+      "e"
+    ],
+    [
+      0.135782,
+      "t"
+    ],
+    [
+      0.138348,
+      " "
+    ],
+    [
+      0.420761,
+      "p"
+    ],
+    [
+      0.060187,
+      "o"
+    ],
+    [
+      0.067901,
+      "d"
+    ],
+    [
+      0.056125,
+      "s"
+    ],
+    [
+      0.857285,
+      "\u001b[?1l\u001b>"
+    ],
+    [
+      4.3e-05,
+      "\u001b[?2004l\r\r\n"
+    ],
+    [
+      0.000969,
+      "\u001b]2;kubectl get pods\u0007\u001b]1;kubectl\u0007"
+    ],
+    [
+      5.7e-05,
+      "\u001b]133;C;\u0007"
+    ],
+    [
+      0.762458,
+      "NAME                                       READY     STATUS    RESTARTS   AGE\r\nmy-jenkins-jenkins-3228283227-4jtpd        0/1       Pending   0          11s\r\nnode-example-javascript-1802202654-75r3r   1/1       Running   0          1h\r\nnode-example-javascript-1802202654-kb8rk   1/1       Running   0          1h\r\n"
+    ],
+    [
+      0.001876,
+      "\u001b[1m\u001b[7m%\u001b[27m\u001b[1m\u001b[0m                                                                                                                                                                                                               \r \r"
+    ],
+    [
+      0.000111,
+      "\u001b]2;idanshahar@Idans-MacBook-Pro: ~/sandbox/Meetups/KubernetesCodeComponents\u0007"
+    ],
+    [
+      2.3e-05,
+      "\u001b]1;..odeComponents\u0007"
+    ],
+    [
+      0.000147,
+      "\u001b]133;D;0\u0007\u001b]1337;RemoteHost=idanshahar@Idans-MacBook-Pro.local\u0007\u001b]1337;CurrentDir=/Users/idanshahar/sandbox/Meetups/KubernetesCodeComponents\u0007"
+    ],
+    [
+      0.093458,
+      "\r\u001b[0m\u001b[27m\u001b[24m\u001b[J\u001b]133;A\u0007\u001b[39m\u001b[0m\u001b[49m\u001b[40m\u001b[39m idanshahar@Idans-MacBook-Pro \u001b[44m\u001b[30m\u001b[30m ~/sandbox/Meetups/KubernetesCodeComponents \u001b[43m\u001b[34m\u001b[30m  master ● \u001b[49m\u001b[33m\u001b[39m \u001b]133;B\u0007\u001b[K"
+    ],
+    [
+      0.000118,
+      "\u001b[?1h\u001b="
+    ],
+    [
+      2.1e-05,
+      "\u001b[?2004h"
+    ],
+    [
+      1.0,
+      "k"
+    ],
+    [
+      0.17696,
+      "\bku"
+    ],
+    [
+      0.096103,
+      "b"
+    ],
+    [
+      0.067741,
+      "e"
+    ],
+    [
+      0.206043,
+      "c"
+    ],
+    [
+      0.169544,
+      "tl\u001b[1m \u001b[0m"
+    ],
+    [
+      0.359172,
+      "\b\u001b[0m g"
+    ],
+    [
+      0.070737,
+      "e"
+    ],
+    [
+      0.128722,
+      "t"
+    ],
+    [
+      0.127593,
+      " "
+    ],
+    [
+      0.169586,
+      "s"
+    ],
+    [
+      0.268582,
+      "v"
+    ],
+    [
+      0.084384,
+      "c"
+    ],
+    [
+      0.258462,
+      "\u001b[?1l\u001b>"
+    ],
+    [
+      3.9e-05,
+      "\u001b[?2004l\r\r\n"
+    ],
+    [
+      0.000766,
+      "\u001b]2;kubectl get svc\u0007\u001b]1;kubectl\u0007"
+    ],
+    [
+      2.7e-05,
+      "\u001b]133;C;\u0007"
+    ],
+    [
+      0.582219,
+      "NAME                       TYPE           CLUSTER-IP     EXTERNAL-IP     PORT(S)          AGE\r\nkubernetes                 ClusterIP      10.0.0.1       <none>          443/TCP          2h\r\nmy-jenkins-jenkins         LoadBalancer   10.0.143.119   <pending>"
+    ],
+    [
+      3.6e-05,
+      "       8080:31744/TCP   16s\r\nmy-jenkins-jenkins-agent   ClusterIP      10.0.24.209    <none>          50000/TCP        16s\r\nnode-example-javascript    LoadBalancer   10.0.166.255   104.46.58.228   8080:31040/TCP   1h\r\n"
+    ],
+    [
+      0.002049,
+      "\u001b[1m\u001b[7m%\u001b[27m\u001b[1m\u001b[0m                                                                                                                                                                                                               \r \r"
+    ],
+    [
+      0.000155,
+      "\u001b]2;idanshahar@Idans-MacBook-Pro: ~/sandbox/Meetups/KubernetesCodeComponents\u0007\u001b]1;..odeComponents\u0007"
+    ],
+    [
+      0.00013,
+      "\u001b]133;D;0\u0007\u001b]1337;RemoteHost=idanshahar@Idans-MacBook-Pro.local\u0007\u001b]1337;CurrentDir=/Users/idanshahar/sandbox/Meetups/KubernetesCodeComponents\u0007"
+    ],
+    [
+      0.098351,
+      "\r\u001b[0m\u001b[27m\u001b[24m\u001b[J\u001b]133;A\u0007\u001b[39m\u001b[0m\u001b[49m\u001b[40m\u001b[39m idanshahar@Idans-MacBook-Pro \u001b[44m\u001b[30m\u001b[30m ~/sandbox/Meetups/KubernetesCodeComponents \u001b[43m\u001b[34m\u001b[30m  master ● \u001b[49m\u001b[33m\u001b[39m \u001b]133;B\u0007\u001b[K"
+    ],
+    [
+      0.000106,
+      "\u001b[?1h\u001b=\u001b[?2004h"
+    ],
+    [
+      1.0,
+      "\u001b[?2004l\r\r\n"
+    ]
+  ]
+}

--- a/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/Chart.yaml
+++ b/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/Chart.yaml
@@ -1,0 +1,16 @@
+appVersion: "2.73"
+description: Open source continuous integration server. It supports multiple SCM tools
+  including CVS, Subversion and Git. It can execute Apache Ant and Apache Maven-based
+  projects as well as arbitrary scripts.
+home: https://jenkins.io/
+icon: https://wiki.jenkins-ci.org/download/attachments/2916393/logo.png
+maintainers:
+- email: lachlan.evenson@microsoft.com
+  name: lachie83
+- email: viglesias@google.com
+  name: viglesiasce
+name: jenkins
+sources:
+- https://github.com/jenkinsci/jenkins
+- https://github.com/jenkinsci/docker-jnlp-slave
+version: 0.13.2

--- a/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/README.md
+++ b/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/README.md
@@ -1,0 +1,197 @@
+# Jenkins Helm Chart
+
+Jenkins master and slave cluster utilizing the Jenkins Kubernetes plugin
+
+* https://wiki.jenkins-ci.org/display/JENKINS/Kubernetes+Plugin
+
+Inspired by the awesome work of Carlos Sanchez <carlos@apache.org>
+
+## Chart Details
+This chart will do the following:
+
+* 1 x Jenkins Master with port 8080 exposed on an external LoadBalancer
+* All using Kubernetes Deployments
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release stable/jenkins
+```
+
+## Configuration
+
+The following tables lists the configurable parameters of the Jenkins chart and their default values.
+
+### Jenkins Master
+
+| Parameter                         | Description                          | Default                                                                      |
+| --------------------------------- | ------------------------------------ | ---------------------------------------------------------------------------- |
+| `Master.Name`                     | Jenkins master name                  | `jenkins-master`                                                             |
+| `Master.Image`                    | Master image name                    | `jenkinsci/jenkins`                                                          |
+| `Master.ImageTag`                 | Master image tag                     | `2.46.1`                                                                     |
+| `Master.ImagePullPolicy`          | Master image pull policy             | `Always`                                                                     |
+| `Master.ImagePullSecret`          | Master image pull secret             | Not set                                                                      |
+| `Master.Component`                | k8s selector key                     | `jenkins-master`                                                             |
+| `Master.UseSecurity`              | Use basic security                   | `true`                                                                       |
+| `Master.AdminUser`                | Admin username (and password) created as a secret if useSecurity is true | `admin`                                  |
+| `Master.Cpu`                      | Master requested cpu                 | `200m`                                                                       |
+| `Master.Memory`                   | Master requested memory              | `256Mi`                                                                      |
+| `Master.RunAsUser`                | uid that jenkins runs with           | `0`                                                                          |
+| `Master.FsGroup`                  | uid that will be used for persistent volume | `0`                                                                   |
+| `Master.ServiceAnnotations`       | Service annotations                  | `{}`                                                                         |
+| `Master.ServiceType`              | k8s service type                     | `LoadBalancer`                                                               |
+| `Master.ServicePort`              | k8s service port                     | `8080`                                                                       |
+| `Master.NodePort`                 | k8s node port                        | Not set                                                                      |
+| `Master.HealthProbes`             | Enable k8s liveness and readiness probes | `true`                                                                   |
+| `Master.HealthProbesTimeout`      | Set the timeout for the liveness and readiness probes | `120`                                                       |
+| `Master.ContainerPort`            | Master listening port                | `8080`                                                                       |
+| `Master.SlaveListenerPort`        | Listening port for agents            | `50000`                                                                      |
+| `Master.LoadBalancerSourceRanges` | Allowed inbound IP addresses         | `0.0.0.0/0`                                                                  |
+| `Master.LoadBalancerIP`           | Optional fixed external IP           | Not set                                                                      |
+| `Master.JMXPort`                  | Open a port, for JMX stats           | Not set                                                                      |
+| `Master.CustomConfigMap`          | Use a custom ConfigMap               | `false`                                                                      |
+| `Master.Ingress.Annotations`      | Ingress annotations                  | `{}`                                                                         |
+| `Master.Ingress.TLS`              | Ingress TLS configuration            | `[]`                                                                         |
+| `Master.InitScripts`              | List of Jenkins init scripts         | Not set                                                                      |
+| `Master.CredentialsXmlSecret`     | Kubernetes secret that contains a 'credentials.xml' file | Not set                                                  |
+| `Master.SecretsFilesSecret`       | Kubernetes secret that contains 'secrets' files | Not set                                                           |
+| `Master.Jobs`                     | Jenkins XML job configs              | Not set                                                                      |
+| `Master.InstallPlugins`           | List of Jenkins plugins to install   | `kubernetes:0.11 workflow-aggregator:2.5 credentials-binding:1.11 git:3.2.0` |
+| `Master.ScriptApproval`           | List of groovy functions to approve  | Not set                                                                      |
+| `Master.NodeSelector`             | Node labels for pod assignment       | `{}`                                                                         |
+| `Master.Tolerations`              | Toleration labels for pod assignment | `{}`                                                                         |
+| `NetworkPolicy.Enabled`           | Enable creation of NetworkPolicy resources. | `false`                                                               |
+| `NetworkPolicy.ApiVersion`        | NetworkPolicy ApiVersion             | `extensions/v1beta1`                                                         |
+| `rbac.install`                    | Create service account and ClusterRoleBinding for Kubernetes plugin | `false`                                       |
+| `rbac.apiVersion`                 | RBAC API version                     | `v1beta1`                                                                    |
+| `rbac.roleRef`                    | Cluster role name to bind to         | `cluster-admin`                                                              |
+
+### Jenkins Agent
+
+| Parameter               | Description                                     | Default                |
+| ----------------------- | ----------------------------------------------- | ---------------------- |
+| `Agent.AlwaysPullImage` | Always pull agent container image before build  | `false`                |
+| `Agent.Enabled`         | Enable Kubernetes plugin jnlp-agent podTemplate | `true`                 |
+| `Agent.Image`           | Agent image name                                | `jenkinsci/jnlp-slave` |
+| `Agent.ImagePullSecret` | Agent image pull secret                         | Not set                |
+| `Agent.ImageTag`        | Agent image tag                                 | `2.62`                 |
+| `Agent.Privileged`      | Agent privileged container                      | `false`                |
+| `Agent.Cpu`             | Agent requested cpu                             | `200m`                 |
+| `Agent.Memory`          | Agent requested memory                          | `256Mi`                |
+| `Agent.volumes`         | Additional volumes                              | `nil`                  |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml stable/jenkins
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Mounting volumes into your Agent pods
+
+Your Jenkins Agents will run as pods, and it's possible to inject volumes where needed:
+
+```yaml
+Agent:
+  volumes:
+  - type: Secret
+    secretName: jenkins-mysecrets
+    mountPath: /var/run/secrets/jenkins-mysecrets
+```
+
+The supported volume types are: `ConfigMap`, `EmptyDir`, `HostPath`, `Nfs`, `Pod`, `Secret`. Each type supports a different set of configurable attributes, defined by [the corresponding Java class](https://github.com/jenkinsci/kubernetes-plugin/tree/master/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes).
+
+## NetworkPolicy
+
+To make use of the NetworkPolicy resources created by default,
+install [a networking plugin that implements the Kubernetes
+NetworkPolicy spec](https://kubernetes.io/docs/tasks/administer-cluster/declare-network-policy#before-you-begin).
+
+For Kubernetes v1.5 & v1.6, you must also turn on NetworkPolicy by setting
+the DefaultDeny namespace annotation. Note: this will enforce policy for _all_ pods in the namespace:
+
+    kubectl annotate namespace default "net.beta.kubernetes.io/network-policy={\"ingress\":{\"isolation\":\"DefaultDeny\"}}"
+
+
+Install helm chart with network policy enabled: 
+
+    $ helm install stable/jenkins --set NetworkPolicy.Enabled=true
+
+## Persistence
+
+The Jenkins image stores persistence under `/var/jenkins_home` path of the container. A dynamically managed Persistent Volume
+Claim is used to keep the data across deployments, by default. This is known to work in GCE, AWS, and minikube. Alternatively,
+a previously configured Persistent Volume Claim can be used.
+
+It is possible to mount several volumes using `Persistence.volumes` and `Persistence.mounts` parameters.
+
+### Persistence Values
+
+| Parameter                   | Description                     | Default         |
+| --------------------------- | ------------------------------- | --------------- |
+| `Persistence.Enabled`       | Enable the use of a Jenkins PVC | `true`          |
+| `Persistence.ExistingClaim` | Provide the name of a PVC       | `nil`           |
+| `Persistence.AccessMode`    | The PVC access mode             | `ReadWriteOnce` |
+| `Persistence.Size`          | The size of the PVC             | `8Gi`           |
+| `Persistence.volumes`       | Additional volumes              | `nil`           |
+| `Persistence.mounts`        | Additional mounts               | `nil`           |
+
+
+#### Existing PersistentVolumeClaim
+
+1. Create the PersistentVolume
+1. Create the PersistentVolumeClaim
+1. Install the chart
+```bash
+$ helm install --name my-release --set Persistence.ExistingClaim=PVC_NAME stable/jenkins
+```
+
+## Custom ConfigMap
+
+When creating a new parent chart with this chart as a dependency, the `CustomConfigMap` parameter can be used to override the default config.xml provided.
+It also allows for providing additional xml configuration files that will be copied into `/var/jenkins_home`. In the parent chart's values.yaml,
+set the `jenkins.Master.CustomConfigMap` value to true like so
+
+```
+jenkins:
+  Master:
+    CustomConfigMap: true
+```
+
+and provide the file `templates/config.tpl` in your parent chart for your use case. You can start by copying the contents of `config.yaml` from this chart into your parent charts `templates/config.tpl` as a basis for customization. Finally, you'll need to wrap the contents of `templates/config.tpl` like so:
+
+```yaml
+{{- define "override_config_map" }}
+    <CONTENTS_HERE>
+{{ end }}
+```
+
+## RBAC
+
+If running upon a cluster with RBAC enabled you will need to do the following:
+
+* `helm install stable/jenkins --set rbac.install=true`
+* Create a Jenkins credential of type Kubernetes service account with service account name provided in the `helm status` output.
+* Under configure Jenkins -- Update the credentials config in the cloud section to use the service account credential you created in the step above.
+
+## Run Jenkins as non root user
+
+The default settings of this helm chart let Jenkins run as root user with uid `0`.
+Due to security reasons you may want to run Jenkins as a non root user. 
+Fortunately the default jenkins docker image `jenkins/jenkins` contains a user `jenkins` with uid `1000` that can be used for this purpose.  
+
+Simply use the following settings to run Jenkins as `jenkins` user with uid `1000`.
+```
+jenkins:
+  Master:
+    RunAsUser: 1000
+    FsGroup: 1000
+```
+
+Docs taken from https://github.com/jenkinsci/docker/blob/master/Dockerfile:
+*Jenkins is run with user `jenkins`, uid = 1000. If you bind mount a volume from the host or a data container,ensure you use the same uid*

--- a/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/templates/NOTES.txt
+++ b/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/templates/NOTES.txt
@@ -1,0 +1,45 @@
+1. Get your '{{ .Values.Master.AdminUser }}' user password by running:
+  printf $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "jenkins.fullname" . }} -o jsonpath="{.data.jenkins-admin-password}" | base64 --decode);echo
+
+{{- if .Values.Master.HostName }}
+
+2. Visit http://{{ .Values.Master.HostName }}
+{{- else }}
+2. Get the Jenkins URL to visit by running these commands in the same shell:
+{{- if contains "NodePort" .Values.Master.ServiceType }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "jenkins.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT/login
+
+{{- else if contains "LoadBalancer" .Values.Master.ServiceType }}
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        You can watch the status of by running 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "jenkins.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "jenkins.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
+  echo http://$SERVICE_IP:{{ .Values.Master.ServicePort }}/login
+
+{{- else if contains "ClusterIP"  .Values.Master.ServiceType }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "component={{ template "jenkins.fullname" . }}-master" -o jsonpath="{.items[0].metadata.name}")
+  echo http://127.0.0.1:{{ .Values.Master.ServicePort }}
+  kubectl port-forward $POD_NAME {{ .Values.Master.ServicePort }}:{{ .Values.Master.ServicePort }}
+
+{{- end }}
+{{- end }}
+
+3. Login with the password from step 1 and the username: {{ .Values.Master.AdminUser }}
+
+For more information on running Jenkins on Kubernetes, visit:
+https://cloud.google.com/solutions/jenkins-on-container-engine
+
+{{- if .Values.Persistence.Enabled }}
+{{- else }}
+#################################################################################
+######   WARNING: Persistence is disabled!!! You will lose your data when   #####
+######            the Jenkins pod is terminated.                            #####
+#################################################################################
+{{- end }}
+
+{{- if .Values.rbac.install }}
+Configure the Kubernetes plugin in Jenkins to use the following Service Account name {{ template "jenkins.fullname" . }} using the following steps:
+  Create a Jenkins credential of type Kubernetes service account with service account name {{ template "jenkins.fullname" . }}
+  Under configure Jenkins -- Update the credentials config in the cloud section to use the service account credential you created in the step above.
+{{- end }}

--- a/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/templates/_helpers.tpl
+++ b/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/templates/_helpers.tpl
@@ -1,0 +1,25 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "jenkins.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "jenkins.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "jenkins.kubernetes-version" -}}
+  {{- range .Values.Master.InstallPlugins -}}
+    {{ if hasPrefix "kubernetes:" . }}
+      {{- $split := splitList ":" . }}
+      {{- printf "%s" (index $split 1 ) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}

--- a/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/templates/config.yaml
+++ b/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/templates/config.yaml
@@ -1,0 +1,183 @@
+{{- if not .Values.Master.CustomConfigMap }}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "jenkins.fullname" . }}
+data:
+  config.xml: |-
+    <?xml version='1.0' encoding='UTF-8'?>
+    <hudson>
+      <disabledAdministrativeMonitors/>
+      <version>{{ .Values.Master.ImageTag }}</version>
+      <numExecutors>0</numExecutors>
+      <mode>NORMAL</mode>
+      <useSecurity>{{ .Values.Master.UseSecurity }}</useSecurity>
+      <authorizationStrategy class="hudson.security.FullControlOnceLoggedInAuthorizationStrategy">
+        <denyAnonymousReadAccess>true</denyAnonymousReadAccess>
+      </authorizationStrategy>
+      <securityRealm class="hudson.security.LegacySecurityRealm"/>
+      <disableRememberMe>false</disableRememberMe>
+      <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$DefaultProjectNamingStrategy"/>
+      <workspaceDir>${JENKINS_HOME}/workspace/${ITEM_FULLNAME}</workspaceDir>
+      <buildsDir>${ITEM_ROOTDIR}/builds</buildsDir>
+      <markupFormatter class="hudson.markup.EscapedMarkupFormatter"/>
+      <jdks/>
+      <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
+      <myViewsTabBar class="hudson.views.DefaultMyViewsTabBar"/>
+      <clouds>
+        <org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud plugin="kubernetes@{{ template "jenkins.kubernetes-version" . }}">
+          <name>kubernetes</name>
+          <templates>
+{{- if .Values.Agent.Enabled }}
+            <org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
+              <inheritFrom></inheritFrom>
+              <name>default</name>
+              <instanceCap>2147483647</instanceCap>
+              <idleMinutes>0</idleMinutes>
+              <label>{{ .Release.Name }}-{{ .Values.Agent.Component }}</label>
+              <nodeSelector>
+                {{- $local := dict "first" true }}
+                {{- range $key, $value := .Values.Agent.NodeSelector }}
+                  {{- if not $local.first }},{{- end }}
+                  {{- $key }}={{ $value }}
+                  {{- $_ := set $local "first" false }}
+                {{- end }}</nodeSelector>
+                <nodeUsageMode>NORMAL</nodeUsageMode>
+              <volumes>
+{{- range $index, $volume := .Values.Agent.volumes }}
+                <org.csanchez.jenkins.plugins.kubernetes.volumes.{{ $volume.type }}Volume>
+{{- range $key, $value := $volume }}{{- if not (eq $key "type") }}
+                  <{{ $key }}>{{ $value }}</{{ $key }}>
+{{- end }}{{- end }}
+                </org.csanchez.jenkins.plugins.kubernetes.volumes.{{ $volume.type }}Volume>
+{{- end }}
+              </volumes>
+              <containers>
+                <org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
+                  <name>jnlp</name>
+                  <image>{{ .Values.Agent.Image }}:{{ .Values.Agent.ImageTag }}</image>
+{{- if .Values.Agent.Privileged }}
+                  <privileged>true</privileged>
+{{- else }}
+                  <privileged>false</privileged>
+{{- end }}
+                  <alwaysPullImage>{{ .Values.Agent.AlwaysPullImage }}</alwaysPullImage>
+                  <workingDir>/home/jenkins</workingDir>
+                  <command></command>
+                  <args>${computer.jnlpmac} ${computer.name}</args>
+                  <ttyEnabled>false</ttyEnabled>
+                  <resourceRequestCpu>{{.Values.Agent.Cpu}}</resourceRequestCpu>
+                  <resourceRequestMemory>{{.Values.Agent.Memory}}</resourceRequestMemory>
+                  <resourceLimitCpu>{{.Values.Agent.Cpu}}</resourceLimitCpu>
+                  <resourceLimitMemory>{{.Values.Agent.Memory}}</resourceLimitMemory>
+                  <envVars>
+                    <org.csanchez.jenkins.plugins.kubernetes.ContainerEnvVar>
+                      <key>JENKINS_URL</key>
+                      <value>http://{{ template "jenkins.fullname" . }}:{{.Values.Master.ServicePort}}{{ default "" .Values.Master.JenkinsUriPrefix }}</value>
+                    </org.csanchez.jenkins.plugins.kubernetes.ContainerEnvVar>
+                  </envVars>
+                </org.csanchez.jenkins.plugins.kubernetes.ContainerTemplate>
+              </containers>
+              <envVars/>
+              <annotations/>
+{{- if .Values.Agent.ImagePullSecret }}
+              <imagePullSecrets>
+                <org.csanchez.jenkins.plugins.kubernetes.PodImagePullSecret>
+                  <name>{{ .Values.Agent.ImagePullSecret }}</name>
+                </org.csanchez.jenkins.plugins.kubernetes.PodImagePullSecret>
+              </imagePullSecrets>
+{{- else }}
+              <imagePullSecrets/>
+{{- end }}
+              <nodeProperties/>
+            </org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
+{{- end -}}
+          </templates>
+          <serverUrl>https://kubernetes.default</serverUrl>
+          <skipTlsVerify>false</skipTlsVerify>
+          <namespace>{{ .Release.Namespace }}</namespace>
+          <jenkinsUrl>http://{{ template "jenkins.fullname" . }}:{{.Values.Master.ServicePort}}{{ default "" .Values.Master.JenkinsUriPrefix }}</jenkinsUrl>
+          <jenkinsTunnel>{{ template "jenkins.fullname" . }}-agent:50000</jenkinsTunnel>
+          <containerCap>10</containerCap>
+          <retentionTimeout>5</retentionTimeout>
+          <connectTimeout>0</connectTimeout>
+          <readTimeout>0</readTimeout>
+        </org.csanchez.jenkins.plugins.kubernetes.KubernetesCloud>
+      </clouds>
+      <quietPeriod>5</quietPeriod>
+      <scmCheckoutRetryCount>0</scmCheckoutRetryCount>
+      <views>
+        <hudson.model.AllView>
+          <owner class="hudson" reference="../../.."/>
+          <name>All</name>
+          <filterExecutors>false</filterExecutors>
+          <filterQueue>false</filterQueue>
+          <properties class="hudson.model.View$PropertyList"/>
+        </hudson.model.AllView>
+      </views>
+      <primaryView>All</primaryView>
+      <slaveAgentPort>50000</slaveAgentPort>
+      <label></label>
+      <nodeProperties/>
+      <globalNodeProperties/>
+      <noUsageStatistics>true</noUsageStatistics>
+    </hudson>
+{{- if .Values.Master.ScriptApproval }}
+  scriptapproval.xml: |-
+    <?xml version='1.0' encoding='UTF-8'?>
+    <scriptApproval plugin="script-security@1.27">
+      <approvedScriptHashes/>
+      <approvedSignatures>
+{{- range $key, $val := .Values.Master.ScriptApproval }}
+        <string>{{ $val }}</string>
+{{- end }}
+      </approvedSignatures>
+      <aclApprovedSignatures/>
+      <approvedClasspathEntries/>
+      <pendingScripts/>
+      <pendingSignatures/>
+      <pendingClasspathEntries/>
+    </scriptApproval>
+{{- end }}
+  apply_config.sh: |-
+    mkdir -p /usr/share/jenkins/ref/secrets/;
+    echo "false" > /usr/share/jenkins/ref/secrets/slave-to-master-security-kill-switch;
+    cp -n /var/jenkins_config/config.xml /var/jenkins_home;
+{{- if .Values.Master.InstallPlugins }}
+    cp /var/jenkins_config/plugins.txt /var/jenkins_home;
+    rm -rf /usr/share/jenkins/ref/plugins/*.lock
+    /usr/local/bin/install-plugins.sh `echo $(cat /var/jenkins_home/plugins.txt)`;
+{{- end }}
+{{- if .Values.Master.ScriptApproval }}
+    cp -n /var/jenkins_config/scriptapproval.xml /var/jenkins_home/scriptApproval.xml;
+{{- end }}
+{{- if .Values.Master.InitScripts }}
+    mkdir -p /var/jenkins_home/init.groovy.d/;
+    cp -n /var/jenkins_config/*.groovy /var/jenkins_home/init.groovy.d/
+{{- end }}
+{{- if .Values.Master.CredentialsXmlSecret }}
+    cp -n /var/jenkins_credentials/credentials.xml /var/jenkins_home;
+{{- end }}
+{{- if .Values.Master.SecretsFilesSecret }}
+    cp -n /var/jenkins_secrets/* /usr/share/jenkins/ref/secrets;
+{{- end }}
+{{- if .Values.Master.Jobs }}
+    for job in $(ls /var/jenkins_jobs); do
+      mkdir -p /var/jenkins_home/jobs/$job
+      cp -n /var/jenkins_jobs/$job /var/jenkins_home/jobs/$job/config.xml
+    done
+{{- end }}
+{{- range $key, $val := .Values.Master.InitScripts }}
+  init{{ $key }}.groovy: |-
+{{ $val | indent 4 }}
+{{- end }}
+  plugins.txt: |-
+{{- if .Values.Master.InstallPlugins }}
+{{- range $index, $val := .Values.Master.InstallPlugins }}
+{{ $val | indent 4 }}
+{{- end }}
+{{- end }}
+{{ else }}
+{{ include "override_config_map" . }}
+{{- end -}}

--- a/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/templates/home-pvc.yaml
+++ b/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/templates/home-pvc.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.Persistence.Enabled (not .Values.Persistence.ExistingClaim) -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+{{- if .Values.Persistence.Annotations }}
+  annotations:
+{{ toYaml .Values.Persistence.Annotations | indent 4 }}
+{{- end }}
+  name: {{ template "jenkins.fullname" . }}
+  labels:
+    app: {{ template "jenkins.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  accessModes:
+    - {{ .Values.Persistence.AccessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.Persistence.Size | quote }}
+{{- if .Values.Persistence.StorageClass }}
+{{- if (eq "-" .Values.Persistence.StorageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.Persistence.StorageClass }}"
+{{- end }}
+{{- end }}
+{{- end }}

--- a/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/templates/jenkins-agent-svc.yaml
+++ b/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/templates/jenkins-agent-svc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "jenkins.fullname" . }}-agent
+  labels:
+    app: {{ template "jenkins.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: "{{ .Release.Name }}-{{ .Values.Master.Component }}"
+spec:
+  ports:
+    - port: {{ .Values.Master.SlaveListenerPort }}
+      targetPort: {{ .Values.Master.SlaveListenerPort }}
+      name: slavelistener
+  selector:
+    component: "{{ .Release.Name }}-{{ .Values.Master.Component }}"
+  type: ClusterIP

--- a/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/templates/jenkins-master-deployment.yaml
+++ b/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/templates/jenkins-master-deployment.yaml
@@ -1,0 +1,203 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "jenkins.fullname" . }}
+  labels:
+    heritage: {{ .Release.Service | quote }}
+    release: {{ .Release.Name | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: "{{ .Release.Name }}-{{ .Values.Master.Name }}"
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      component: "{{ .Release.Name }}-{{ .Values.Master.Component }}"
+  template:
+    metadata:
+      labels:
+        app: {{ template "jenkins.fullname" . }}
+        heritage: {{ .Release.Service | quote }}
+        release: {{ .Release.Name | quote }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        component: "{{ .Release.Name }}-{{ .Values.Master.Component }}"
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
+    spec:
+      {{- if .Values.Master.NodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.Master.NodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.Master.Tolerations }}
+      tolerations:
+{{ toYaml .Values.Master.Tolerations | indent 8 }}
+      {{- end }}
+      securityContext:
+        runAsUser: {{ default 0 .Values.Master.RunAsUser }}
+{{- if and (.Values.Master.RunAsUser) (.Values.Master.FsGroup) }}
+{{- if not (eq .Values.Master.RunAsUser 0.0) }}
+        fsGroup: {{ .Values.Master.FsGroup }}
+{{- end }}
+{{- end }}
+      serviceAccountName: {{ if .Values.rbac.install }}{{ template "jenkins.fullname" . }}{{ else }}"{{ .Values.rbac.serviceAccountName }}"{{ end }}
+      initContainers:
+        - name: "copy-default-config"
+          image: "{{ .Values.Master.Image }}:{{ .Values.Master.ImageTag }}"
+          imagePullPolicy: "{{ .Values.Master.ImagePullPolicy }}"
+          command: [ "sh", "/var/jenkins_config/apply_config.sh" ]
+          volumeMounts:
+            -
+              mountPath: /var/jenkins_home
+              name: jenkins-home
+            -
+              mountPath: /var/jenkins_config
+              name: jenkins-config
+            {{- if .Values.Master.CredentialsXmlSecret }}
+            -
+              mountPath: /var/jenkins_credentials
+              name: jenkins-credentials
+              readOnly: true
+            {{- end }}
+            {{- if .Values.Master.SecretsFilesSecret }}
+            -
+              mountPath: /var/jenkins_secrets
+              name: jenkins-secrets
+              readOnly: true
+            {{- end }}
+            {{- if .Values.Master.Jobs }}
+            -
+              mountPath: /var/jenkins_jobs
+              name: jenkins-jobs
+              readOnly: true
+            {{- end }}
+            -
+              mountPath: /usr/share/jenkins/ref/plugins/
+              name: plugin-dir
+            -
+              mountPath: /usr/share/jenkins/ref/secrets/
+              name: secrets-dir
+      containers:
+        - name: {{ template "jenkins.fullname" . }}
+          image: "{{ .Values.Master.Image }}:{{ .Values.Master.ImageTag }}"
+          imagePullPolicy: "{{ .Values.Master.ImagePullPolicy }}"
+          {{- if .Values.Master.UseSecurity }}
+          args: [ "--argumentsRealm.passwd.$(ADMIN_USER)=$(ADMIN_PASSWORD)",  "--argumentsRealm.roles.$(ADMIN_USER)=admin"]
+          {{- end }}
+          env:
+            - name: JAVA_OPTS
+              value: "{{ default "" .Values.Master.JavaOpts}}"
+            - name: JENKINS_OPTS
+              value: "{{ if .Values.Master.JenkinsUriPrefix }}--prefix={{ .Values.Master.JenkinsUriPrefix }} {{ end }}{{ default "" .Values.Master.JenkinsOpts}}"
+            {{- if .Values.Master.UseSecurity }}
+            - name: ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "jenkins.fullname" . }}
+                  key: jenkins-admin-password
+            - name: ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "jenkins.fullname" . }}
+                  key: jenkins-admin-user
+            {{- end }}
+          ports:
+            - containerPort: {{ .Values.Master.ContainerPort }}
+              name: http
+            - containerPort: {{ .Values.Master.SlaveListenerPort }}
+              name: slavelistener
+            {{- if .Values.Master.JMXPort }}
+            - containerPort: {{ .Values.Master.JMXPort }}
+              name: jmx
+            {{- end }}
+{{- if .Values.Master.HealthProbes }}
+          livenessProbe:
+            httpGet:
+              path: /login
+              port: http
+            initialDelaySeconds: {{ .Values.Master.HealthProbesTimeout }}
+          readinessProbe:
+            httpGet:
+              path: /login
+              port: http
+            initialDelaySeconds: {{ .Values.Master.HealthProbesTimeout }}
+{{- end }}
+          resources:
+            requests:
+              cpu: "{{ .Values.Master.Cpu }}"
+              memory: "{{ .Values.Master.Memory }}"
+          volumeMounts:
+{{- if .Values.Persistence.mounts }}
+{{ toYaml .Values.Persistence.mounts | indent 12 }}
+{{- end }}
+            -
+              mountPath: /var/jenkins_home
+              name: jenkins-home
+              readOnly: false
+            -
+              mountPath: /var/jenkins_config
+              name: jenkins-config
+              readOnly: true
+            {{- if .Values.Master.CredentialsXmlSecret }}
+            -
+              mountPath: /var/jenkins_credentials
+              name: jenkins-credentials
+              readOnly: true
+            {{- end }}
+            {{- if .Values.Master.SecretsFilesSecret }}
+            -
+              mountPath: /var/jenkins_secrets
+              name: jenkins-secrets
+              readOnly: true
+            {{- end }}
+            {{- if .Values.Master.Jobs }}
+            -
+              mountPath: /var/jenkins_jobs
+              name: jenkins-jobs
+              readOnly: true
+            {{- end }}
+            -
+              mountPath: /usr/share/jenkins/ref/plugins/
+              name: plugin-dir
+              readOnly: false
+            -
+              mountPath: /usr/share/jenkins/ref/secrets/
+              name: secrets-dir
+              readOnly: false
+      volumes:
+{{- if .Values.Persistence.volumes }}
+{{ toYaml .Values.Persistence.volumes | indent 6 }}
+{{- end }}
+      - name: jenkins-config
+        configMap:
+          name: {{ template "jenkins.fullname" . }}
+      {{- if .Values.Master.CredentialsXmlSecret }}
+      - name: jenkins-credentials
+        secret:
+          secretName: {{ .Values.Master.CredentialsXmlSecret }}
+      {{- end }}
+      {{- if .Values.Master.SecretsFilesSecret }}
+      - name: jenkins-secrets
+        secret:
+          secretName: {{ .Values.Master.SecretsFilesSecret }}
+      {{- end }}
+      {{- if .Values.Master.Jobs }}
+      - name: jenkins-jobs
+        configMap:
+          name: {{ template "jenkins.fullname" . }}-jobs
+      {{- end }}
+      - name: plugin-dir
+        emptyDir: {}
+      - name: secrets-dir
+        emptyDir: {}
+      - name: jenkins-home
+      {{- if .Values.Persistence.Enabled }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.Persistence.ExistingClaim | default (include "jenkins.fullname" .) }}
+      {{- else }}
+        emptyDir: {}
+      {{- end -}}
+{{- if .Values.Master.ImagePullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.Master.ImagePullSecret }}
+{{- end -}}

--- a/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/templates/jenkins-master-ingress.yaml
+++ b/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/templates/jenkins-master-ingress.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.Master.HostName }}
+apiVersion: {{ .Values.NetworkPolicy.ApiVersion }}
+kind: Ingress
+metadata:
+{{- if .Values.Master.Ingress.Annotations }}
+  annotations:
+{{ toYaml .Values.Master.Ingress.Annotations | indent 4 }}
+{{- end }}
+  name: {{ template "jenkins.fullname" . }}
+spec:
+  rules:
+  - host: {{ .Values.Master.HostName | quote }}
+    http:
+      paths:
+      - backend:
+          serviceName: {{ template "jenkins.fullname" . }}
+          servicePort: {{ .Values.Master.ServicePort }}
+{{- if .Values.Master.Ingress.TLS }}
+  tls:
+{{ toYaml .Values.Master.Ingress.TLS | indent 4 }}
+{{- end -}}
+{{- end }}

--- a/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/templates/jenkins-master-networkpolicy.yaml
+++ b/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/templates/jenkins-master-networkpolicy.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.NetworkPolicy.Enabled }}
+kind: NetworkPolicy
+apiVersion: {{ .Values.NetworkPolicy.ApiVersion }}
+metadata:
+  name: "{{ .Release.Name }}-{{ .Values.Master.Component }}"
+spec:
+  podSelector:
+    matchLabels:
+      component: "{{ .Release.Name }}-{{ .Values.Master.Component }}"
+  ingress:
+    # Allow web access to the UI
+    - ports:
+      - port: {{ .Values.Master.ContainerPort }}
+    # Allow inbound connections from slave
+    - from:
+      - podSelector:
+          matchLabels:
+            "jenkins/{{ .Release.Name }}-{{ .Values.Agent.Component }}": "true"
+      ports:
+      - port: {{ .Values.Master.SlaveListenerPort }}
+{{- if .Values.Agent.Enabled }}
+---
+kind: NetworkPolicy
+apiVersion: {{ .Values.NetworkPolicy.ApiVersion }}
+metadata:
+  name: "{{ .Release.Name }}-{{ .Values.Agent.Component }}"
+spec:
+  podSelector:
+    matchLabels:
+      # DefaultDeny
+      "jenkins/{{ .Release.Name }}-{{ .Values.Agent.Component }}": "true"
+{{- end }}
+{{- end }}

--- a/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/templates/jenkins-master-svc.yaml
+++ b/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/templates/jenkins-master-svc.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{template "jenkins.fullname" . }}
+  labels:
+    app: {{ template "jenkins.fullname" . }}
+    heritage: {{.Release.Service | quote }}
+    release: {{.Release.Name | quote }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    component: "{{.Release.Name}}-{{.Values.Master.Component}}"
+{{- if .Values.Master.ServiceAnnotations }}
+  annotations:
+{{ toYaml .Values.Master.ServiceAnnotations | indent 4 }}
+{{- end }}
+spec:
+  ports:
+    - port: {{.Values.Master.ServicePort}}
+      name: http
+      targetPort: {{.Values.Master.ContainerPort}}
+      {{if (and (eq .Values.Master.ServiceType "NodePort") (not (empty .Values.Master.NodePort)))}}
+      nodePort: {{.Values.Master.NodePort}}
+      {{end}}
+  selector:
+    component: "{{.Release.Name}}-{{.Values.Master.Component}}"
+  type: {{.Values.Master.ServiceType}}
+  {{if eq .Values.Master.ServiceType "LoadBalancer"}}
+  loadBalancerSourceRanges: {{.Values.Master.LoadBalancerSourceRanges}}
+  {{if .Values.Master.LoadBalancerIP}}
+  loadBalancerIP: {{.Values.Master.LoadBalancerIP}}
+  {{end}}
+  {{end}}

--- a/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/templates/jenkins-test.yaml
+++ b/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/templates/jenkins-test.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-ui-test-{{ randAlphaNum 5 | lower }}"
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  {{- if .Values.Master.NodeSelector }}
+  nodeSelector:
+{{ toYaml .Values.Master.NodeSelector | indent 4 }}
+  {{- end }}
+  {{- if .Values.Master.Tolerations }}
+  tolerations:
+{{ toYaml .Values.Master.Tolerations | indent 4 }}
+  {{- end }}
+  initContainers:
+    - name: "test-framework"
+      image: "dduportal/bats:0.4.0"
+      command:
+      - "bash"
+      - "-c"
+      - |
+        set -ex
+        # copy bats to tools dir
+        cp -R /usr/local/libexec/ /tools/bats/
+      volumeMounts:
+      - mountPath: /tools
+        name: tools
+  containers:
+    - name: {{ .Release.Name }}-ui-test
+      image: {{ .Values.Master.Image }}:{{ .Values.Master.ImageTag }}
+      command: ["/tools/bats/bats", "-t", "/tests/run.sh"]
+      volumeMounts:
+      - mountPath: /tests
+        name: tests
+        readOnly: true
+      - mountPath: /tools
+        name: tools
+  volumes:
+  - name: tests
+    configMap:
+      name: {{ template "jenkins.fullname" . }}-tests
+  - name: tools
+    emptyDir: {}
+  restartPolicy: Never

--- a/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/templates/jobs.yaml
+++ b/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/templates/jobs.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.Master.Jobs }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "jenkins.fullname" . }}-jobs
+data:
+{{ .Values.Master.Jobs | indent 2 }}
+{{- end -}}

--- a/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/templates/rbac.yaml
+++ b/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/templates/rbac.yaml
@@ -1,0 +1,20 @@
+{{ if .Values.rbac.install }}
+{{- $serviceName := include "jenkins.fullname" . -}}
+apiVersion: rbac.authorization.k8s.io/{{ required "A valid .Values.rbac.apiVersion entry required!" .Values.rbac.apiVersion }}
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $serviceName }}-role-binding
+  labels:
+    app: {{ $serviceName }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.rbac.roleRef }}
+subjects:
+- kind: ServiceAccount
+  name: {{ $serviceName }}
+  namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/templates/secret.yaml
+++ b/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/templates/secret.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.Master.UseSecurity }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "jenkins.fullname" . }}
+  labels:
+    app: {{ template "jenkins.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  {{ if .Values.Master.AdminPassword }}
+  jenkins-admin-password: {{ .Values.Master.AdminPassword | b64enc | quote }}
+  {{ else }}
+  jenkins-admin-password: {{ randAlphaNum 10 | b64enc | quote }}
+  {{ end }}
+  jenkins-admin-user: {{ .Values.Master.AdminUser | b64enc | quote }}
+{{- end }}

--- a/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/templates/service-account.yaml
+++ b/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/templates/service-account.yaml
@@ -1,0 +1,12 @@
+{{ if .Values.rbac.install }}
+{{- $serviceName := include "jenkins.fullname" . -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $serviceName }}
+  labels:
+    app: {{ $serviceName }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+{{ end }}

--- a/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/templates/test-config.yaml
+++ b/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/templates/test-config.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "jenkins.fullname" . }}-tests
+data:
+  run.sh: |-
+    @test "Testing Jenkins UI is accessible" {
+      curl --retry 24 --retry-delay 10 {{ .Release.Name }}-jenkins:{{ .Values.Master.ServicePort }}{{ default "" .Values.Master.JenkinsUriPrefix }}/login
+    }

--- a/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/values.yaml
+++ b/devops/aks/nodelessKubernetesOnK8S/jenkins-helm/values.yaml
@@ -1,0 +1,160 @@
+# Default values for jenkins.
+# This is a YAML-formatted file.
+# Declare name/value pairs to be passed into your templates.
+# name: value
+
+Master:
+  Name: jenkins-master
+  Image: "jenkins/jenkins"
+  ImageTag: "lts"
+  ImagePullPolicy: "Always"
+# ImagePullSecret: jenkins
+  Component: "jenkins-master"
+  UseSecurity: true
+  AdminUser: admin
+  # AdminPassword: <defaults to random>
+  Cpu: "200m"
+  Memory: "256Mi"
+  # Set min/max heap here if needed with:
+  # JavaOpts: "-Xms512m -Xmx512m"
+  # JenkinsOpts: ""
+  # JenkinsUriPrefix: "/jenkins"
+  # Set RunAsUser to 1000 to let Jenkins run as non-root user 'jenkins' which exists in 'jenkins/jenkins' docker image.
+  # When setting RunAsUser to a different value than 0 also set FsGroup to the same value:
+  # RunAsUser: <defaults to 0>
+  # FsGroup: <will be omitted in deployment if RunAsUser is 0>
+  ServicePort: 8080
+  # For minikube, set this to NodePort, elsewhere use LoadBalancer
+  # Use ClusterIP if your setup includes ingress controller
+  ServiceType: LoadBalancer
+  # Master Service annotations
+  ServiceAnnotations: {}
+  #   service.beta.kubernetes.io/aws-load-balancer-backend-protocol: https
+  # Used to create Ingress record (should used with ServiceType: ClusterIP)
+  # HostName: jenkins.cluster.local
+  # NodePort: <to set explicitly, choose port between 30000-32767
+  ContainerPort: 8080
+  # Enable Kubernetes Liveness and Readiness Probes
+  HealthProbes: true
+  HealthProbesTimeout: 60
+  SlaveListenerPort: 50000
+  LoadBalancerSourceRanges:
+  - 0.0.0.0/0
+  # Optionally assign a known public LB IP
+  # LoadBalancerIP: 1.2.3.4
+  # Optionally configure a JMX port
+  # requires additional JavaOpts, ie
+  # JavaOpts: >
+  #   -Dcom.sun.management.jmxremote.port=4000
+  #   -Dcom.sun.management.jmxremote.authenticate=false
+  #   -Dcom.sun.management.jmxremote.ssl=false
+  # JMXPort: 4000
+  # List of plugins to be install during Jenkins master start
+  InstallPlugins:
+    - kubernetes:1.1
+    - workflow-aggregator:2.5
+    - workflow-job:2.15
+    - credentials-binding:1.13
+    - git:3.6.4
+    - azure-container-agents:0.4.1
+    - azure-ad:0.3.0
+  # Used to approve a list of groovy functions in pipelines used the script-security plugin. Can be viewed under /scriptApproval
+  # ScriptApproval:
+  #   - "method groovy.json.JsonSlurperClassic parseText java.lang.String"
+  #   - "new groovy.json.JsonSlurperClassic"
+  # List of groovy init scripts to be executed during Jenkins master start
+  InitScripts:
+  #  - |
+  #    print 'adding global pipeline libraries, register properties, bootstrap jobs...'
+  # Kubernetes secret that contains a 'credentials.xml' for Jenkins
+  # CredentialsXmlSecret: jenkins-credentials
+  # Kubernetes secret that contains files to be put in the Jenkins 'secrets' directory,
+  # useful to manage encryption keys used for credentials.xml for instance (such as
+  # master.key and hudson.util.Secret)
+  # SecretsFilesSecret: jenkins-secrets
+  # Jenkins XML job configs to provision
+  # Jobs: |-
+  #   test: |-
+  #     <<xml here>>
+  CustomConfigMap: false
+  # Node labels and tolerations for pod assignment
+  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
+  NodeSelector: {}
+  Tolerations: {}
+
+  Ingress:
+    Annotations:
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+
+    TLS:
+    # - secretName: jenkins.cluster.local
+    #   hosts:
+    #     - jenkins.cluster.local
+
+Agent:
+  Enabled: true
+  Image: jenkins/jnlp-slave
+  ImageTag: 3.10-1
+# ImagePullSecret: jenkins
+  Component: "jenkins-slave"
+  Privileged: false
+  Cpu: "200m"
+  Memory: "256Mi"
+  # You may want to change this to true while testing a new image
+  AlwaysPullImage: false
+  # You can define the volumes that you want to mount for this container
+  # Allowed types are: ConfigMap, EmptyDir, HostPath, Nfs, Pod, Secret
+  # Configure the attributes as they appear in the corresponding Java class for that type
+  # https://github.com/jenkinsci/kubernetes-plugin/tree/master/src/main/java/org/csanchez/jenkins/plugins/kubernetes/volumes
+  volumes:
+  # - type: Secret
+  #   secretName: mysecret
+  #   mountPath: /var/myapp/mysecret
+  NodeSelector: {}
+  # Key Value selectors. Ex:
+  # jenkins-agent: v1
+
+Persistence:
+  Enabled: true
+  ## A manually managed Persistent Volume and Claim
+  ## Requires Persistence.Enabled: true
+  ## If defined, PVC must be created manually before volume will be bound
+  # ExistingClaim:
+
+  ## jenkins data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  StorageClass: "default"
+
+  Annotations: {}
+  AccessMode: ReadWriteOnce
+  Size: 8Gi
+  volumes:
+  #  - name: nothing
+  #    emptyDir: {}
+  mounts:
+  #  - mountPath: /var/nothing
+  #    name: nothing
+  #    readOnly: true
+
+NetworkPolicy:
+  # Enable creation of NetworkPolicy resources.
+  Enabled: false
+  # For Kubernetes v1.4, v1.5 and v1.6, use 'extensions/v1beta1'
+  # For Kubernetes v1.7, use 'networking.k8s.io/v1'
+  ApiVersion: extensions/v1beta1
+
+## Install Default RBAC roles and bindings
+rbac:
+  install: false
+  serviceAccountName: default
+  # RBAC api version (currently either v1beta1 or v1alpha1)
+  apiVersion: v1beta1
+  # Cluster role reference
+  roleRef: cluster-admin

--- a/devops/aks/nodelessKubernetesOnK8S/jenkins/Dockerfile
+++ b/devops/aks/nodelessKubernetesOnK8S/jenkins/Dockerfile
@@ -1,0 +1,22 @@
+From jenkins/jnlp-slave:3.16-1
+USER root
+
+ENV DRAFT_LATEST_VERSION="v0.7.0"
+
+RUN apt-get update && apt-get install -y \
+    curl
+
+RUN apt-get update -y \
+	&& apt-get install -y libltdl7-dev \
+	&& rm -rf /var/lib/apt/lists/* 
+
+RUN curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh \
+	&& chmod 700 get_helm.sh \
+	&& ./get_helm.sh
+
+RUN curl -LO \  
+    https://github.com/Azure/draft/releases/download/${DRAFT_LATEST_VERSION}/draft-${DRAFT_LATEST_VERSION}-linux-amd64.tar.gz
+RUN tar -xvf draft-${DRAFT_LATEST_VERSION}-linux-amd64.tar.gz
+RUN mv linux-amd64/draft /usr/local/bin 
+
+

--- a/devops/aks/nodelessKubernetesOnK8S/jenkins/Jenkinsfile
+++ b/devops/aks/nodelessKubernetesOnK8S/jenkins/Jenkinsfile
@@ -1,0 +1,33 @@
+	
+node {
+    withCredentials([
+      [$class: 'UsernamePasswordMultiBinding', credentialsId: 'docker-hub-credentials', usernameVariable: 'DOCKER_USER', passwordVariable: 'DOCKER_PASS'],
+    ]) {
+        stage('login') {
+           
+            sh """
+                docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
+            """
+        }
+        stage('Preparation') {
+          git 'https://github.com/idanshahar/K8SCodeComponentsMeetup.git'
+          
+        }
+        stage('Build') {
+            
+            app = docker.build("idanshahar/node-example","-f ./node/Dockerfile ./node")
+        
+        }
+        stage('Push') {
+            withDockerRegistry([credentialsId: 'docker-hub-credentials']) {
+                app.push("${BUILD_NUMBER}")
+                app.push("latest")
+            }
+        }
+        stage('Deploy') {
+            sh """
+                helm upgrade --install node-example -f node/charts/javascript/values.yaml ./node/charts/javascript --set image.repository=idanshahar/node-example,image.tag=${BUILD_NUMBER},service.type=LoadBalancer
+            """
+        }
+    }
+}

--- a/devops/aks/nodelessKubernetesOnK8S/node-draft/index.js
+++ b/devops/aks/nodelessKubernetesOnK8S/node-draft/index.js
@@ -1,0 +1,17 @@
+const http = require('http');
+const port = process.env.PORT || 8080;
+
+const requestHandler = (request, response) => {
+  console.log(request.url);
+  response.end("Draft is awesome!");
+}
+
+const server = http.createServer(requestHandler);
+
+server.listen(port, (err) => {
+  if (err) {
+    return console.log(err);
+  }
+
+  console.log(`server is listening on ${port}`);
+})

--- a/devops/aks/nodelessKubernetesOnK8S/node-draft/package.json
+++ b/devops/aks/nodelessKubernetesOnK8S/node-draft/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "example-nodejs",
+  "version": "0.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  }
+}

--- a/devops/aks/nodelessKubernetesOnK8S/node/.draftignore
+++ b/devops/aks/nodelessKubernetesOnK8S/node/.draftignore
@@ -1,0 +1,4 @@
+*.swp
+*.tmp
+*.temp
+.git*

--- a/devops/aks/nodelessKubernetesOnK8S/node/Dockerfile
+++ b/devops/aks/nodelessKubernetesOnK8S/node/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:8-onbuild
+ENV PORT 8080
+EXPOSE 8080
+RUN npm install
+CMD ["npm", "start"]

--- a/devops/aks/nodelessKubernetesOnK8S/node/charts/javascript/.helmignore
+++ b/devops/aks/nodelessKubernetesOnK8S/node/charts/javascript/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/devops/aks/nodelessKubernetesOnK8S/node/charts/javascript/Chart.yaml
+++ b/devops/aks/nodelessKubernetesOnK8S/node/charts/javascript/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: javascript
+version: v0.1.0

--- a/devops/aks/nodelessKubernetesOnK8S/node/charts/javascript/templates/NOTES.txt
+++ b/devops/aks/nodelessKubernetesOnK8S/node/charts/javascript/templates/NOTES.txt
@@ -1,0 +1,15 @@
+
+{{- if contains "NodePort" .Values.service.type }}
+  Get the application URL by running these commands:
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT/login
+{{- else if contains "LoadBalancer" .Values.service.type }}
+  Get the application URL by running these commands:
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
+{{- else }}
+  http://{{ .Release.Name }}.{{ .Values.basedomain }} to access your application
+{{- end }}

--- a/devops/aks/nodelessKubernetesOnK8S/node/charts/javascript/templates/_helpers.tpl
+++ b/devops/aks/nodelessKubernetesOnK8S/node/charts/javascript/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/devops/aks/nodelessKubernetesOnK8S/node/charts/javascript/templates/deployment.yaml
+++ b/devops/aks/nodelessKubernetesOnK8S/node/charts/javascript/templates/deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    draft: {{ default "draft-app" .Values.draft }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        draft: {{ default "draft-app" .Values.draft }}
+        app: {{ template "fullname" . }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: {{ .Values.service.internalPort }}
+        resources:
+{{ toYaml .Values.resources | indent 12 }}

--- a/devops/aks/nodelessKubernetesOnK8S/node/charts/javascript/templates/service.yaml
+++ b/devops/aks/nodelessKubernetesOnK8S/node/charts/javascript/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ .Values.service.externalPort }}
+    targetPort: {{ .Values.service.internalPort }}
+    protocol: TCP
+    name: {{ .Values.service.name }}
+  selector:
+    app: {{ template "fullname" . }}

--- a/devops/aks/nodelessKubernetesOnK8S/node/charts/javascript/values.yaml
+++ b/devops/aks/nodelessKubernetesOnK8S/node/charts/javascript/values.yaml
@@ -1,0 +1,18 @@
+# Default values for node.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 2
+image:
+  pullPolicy: IfNotPresent
+service:
+  name: node
+  type: ClusterIP
+  externalPort: 8080
+  internalPort: 8080
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi

--- a/devops/aks/nodelessKubernetesOnK8S/node/draft.toml
+++ b/devops/aks/nodelessKubernetesOnK8S/node/draft.toml
@@ -1,0 +1,7 @@
+[environments]
+  [environments.development]
+    name = "node"
+    namespace = "default"
+    wait = false
+    watch = false
+    watch_delay = 2

--- a/devops/aks/nodelessKubernetesOnK8S/node/index.js
+++ b/devops/aks/nodelessKubernetesOnK8S/node/index.js
@@ -1,0 +1,17 @@
+const http = require('http');
+const port = process.env.PORT || 8080;
+
+const requestHandler = (request, response) => {
+  console.log(request.url);
+  response.end("Hello <Code> Components TLV!");
+}
+
+const server = http.createServer(requestHandler);
+
+server.listen(port, (err) => {
+  if (err) {
+    return console.log(err);
+  }
+
+  console.log(`server is listening on ${port}`);
+})

--- a/devops/aks/nodelessKubernetesOnK8S/node/package.json
+++ b/devops/aks/nodelessKubernetesOnK8S/node/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "example-nodejs",
+  "version": "0.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  }
+}

--- a/devops/aks/nodelessKubernetesOnK8S/scripts/draft.sh
+++ b/devops/aks/nodelessKubernetesOnK8S/scripts/draft.sh
@@ -1,0 +1,5 @@
+draft init
+
+draft create
+
+draft up

--- a/devops/aks/nodelessKubernetesOnK8S/scripts/helm.sh
+++ b/devops/aks/nodelessKubernetesOnK8S/scripts/helm.sh
@@ -1,0 +1,5 @@
+helm install --name my-jenkins stable/jenkins
+
+helm install --name influxdb stable/influxdb
+helm install stable/heapster
+helm install stable/grafana

--- a/devops/aks/nodelessKubernetesOnK8S/scripts/requirements.txt
+++ b/devops/aks/nodelessKubernetesOnK8S/scripts/requirements.txt
@@ -1,0 +1,4 @@
+azure cli - https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest
+kubectl - https://kubernetes.io/docs/tasks/tools/install-kubectl/
+draft - https://github.com/Azure/draft/blob/master/docs/install.md
+helm - https://github.com/kubernetes/helm/blob/master/docs/install.md


### PR DESCRIPTION
This commit includes 3 demos:
1. A CI/CD pipeline for Kubernetes applications with nodeless Jenkins (Containerized Jenkins Slaves) that runs on top of Kubernetes cluster (AKS). I used Helm for deploying this setup.
2. Containerize & deploy an application with Draft.
3. Kubernetes monitoring solutions -  I demonstrated this with Heapster, Grafana, and influxDB.